### PR TITLE
Redirects to /dev/null for fedora package check

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -11,7 +11,7 @@ install_dependencies() {
   info "Checking dependencies"
   if [[ "$ID" == "fedora" ]]; then
     for PKG in qemu-system-x86 libguestfs-tools-c make git; do
-      if ! dnf list installed $PKG >&- 2>&-; then
+      if ! dnf list installed $PKG &> /dev/null; then
         die "Please install '$PKG'"
       fi
     done


### PR DESCRIPTION
Changes redirection during package check to prevent wrong exit code on Fedora 25

Fixes #4