### PR TITLE
Up VERSION to 0.3.0 and remove reference to demo-pv.yaml

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -19,10 +19,9 @@ clone_and_run() {
     die "KubeVirt is already deployed. Exiting."
   fi
   info "Running the demo"
-  export VERSION=v0.1.0
+  export VERSION=v0.3.0
   kubectl create \
     -f https://github.com/kubevirt/kubevirt/releases/download/$VERSION/kubevirt.yaml \
-    -f manifests/demo-pv.yaml
   echo "KubeVirt is now deployed, please follow the README for the next steps:"
   echo "https://github.com/kubevirt/demo#deploy-a-virtualmachine"
 }


### PR DESCRIPTION
demo.sh was failing because it cannot find demo-py.yaml.
demo-pv.yaml was removed in
https://github.com/kubevirt/demo/commit/ef70c30818a3512d4c65b2cc25ca6c1559a531b7